### PR TITLE
fix: Add correct default cover image.

### DIFF
--- a/components/Game/Form.tsx
+++ b/components/Game/Form.tsx
@@ -54,14 +54,14 @@ interface GameFormProps {
 let MESSAGE_SUBMIT_KEY: string | number
 
 export const defaultCoverLinks = new Map([
-  [GameEngine.DEFAULT, 'http://n.sinaimg.cn/auto/transform/20170521/Z87u-fyfkzhs7969292.jpg'],
+  [GameEngine.DEFAULT, 'https://user-images.githubusercontent.com/2507027/178090990-c77b5127-14b7-40a6-a32a-134d63073177.png'],
   [
     GameEngine.RM2K3E,
-    'https://image.w3itch.io/w3itch-test/attachment/30/world-overview.crystal2.8dde7d50-ec9a-11ec-956c-03700aa82971.png',
+    'https://user-images.githubusercontent.com/2507027/178090990-c77b5127-14b7-40a6-a32a-134d63073177.png',
   ],
   [
     GameEngine.DOWNLOADABLE,
-    'https://dotnet.microsoft.com/static/images/redesign/download/dotnet-framework-runtime.svg?v=22xvQuHVYJL7LD0xeWgHfLKUNROSdPrvv0q3aBlVvsY',
+    'https://user-images.githubusercontent.com/2507027/178090990-c77b5127-14b7-40a6-a32a-134d63073177.png',
   ],
 ])
 

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -141,14 +141,7 @@ const HasGameProject: FC<HasGameProjectProps> = ({
                       <div className={styles.publish_status}>
                         <span className={`${styles.tag_bubble} ${styles.green}`}>
                           <Link href={urlGame(item.id)}>
-                            <a>Published</a>
-                          </Link>
-                        </span>
-                      </div>
-                      <div className={styles.publish_status}>
-                        <span className={`${styles.tag_bubble} ${styles.blue}`}>
-                          <Link href={urlGame(item.id)}>
-                            <a>{item.accessType}</a>
+                          <a>{item.accessType}</a>
                           </Link>
                         </span>
                       </div>


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please put an `x` in boxes that apply. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Does this PR require a change to the documentation?** (check one)

- [ ] Yes
- [x] No

If yes, please update the documentation accordingly.

**Does this PR require a change to the environment variables configuration?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the changes that need to be updated in the configuration (put your example environment variables in the code block below).

```bash

```

## Description

Add correct default cover image.
Suggest storing image inside the server instead of storing on other place.

Fixes #291 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Desktop:**

<!-- Please complete the following information -->
<!-- Or paste your full system/browser information, e.g. the output of `uname -a`  -->
<!-- Darwin MacPro 20.6.0 Darwin Kernel Version 20.6.0 ... arm64  -->

- OS:
  - [ ] Windows [version]
  - [ ] macOS [version]
  - [ ] Linux [version]
- Browser [e.g. chrome, safari]

**Smartphone:**

<!-- Please complete the following information -->

- Device: [e.g. iPhone6]
- OS: [e.g. iOS8.1]
- Browser [e.g. stock browser, safari]

## Screenshots

Remove if no visual changes have been made.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
